### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: hookla
+  description: Hookla webhook delivery service.
+  annotations:
+    github.com/project-slug: widgetbot-io/hookla
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/kubernetes-id: hookla
+  links:
+    - url: https://github.com/widgetbot-io/hookla
+      title: Source
+      icon: github
+  tags:
+    - side-projects
+spec:
+  type: service
+  lifecycle: production
+  owner: group:side-projects
+  system: side-projects

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# hookla
+
+Hookla webhook delivery service.
+
+> This file is a Backstage TechDocs stub. Replace with real architecture / runbook content as you have time. Backstage will render this directory as the component documentation tab.
+
+## Quick links
+
+- [Source on GitHub](https://github.com/widgetbot-io/hookla)
+- Owner: `group:side-projects`
+- System: `side-projects`
+
+## Where it runs
+
+See the Kubernetes tab for live instances. The K8s plugin queries every configured cluster for workloads labelled `backstage.io/kubernetes-id: hookla`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: hookla
+docs_dir: docs
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- Adds `catalog-info.yaml` so this repo is auto-discovered by WidgetBot Backstage at https://backstage.widgetbot.internal
- Adds a minimal `mkdocs.yml` + `docs/index.md` so the TechDocs tab renders on day 1

## Context
Component definition pins ownership (`group:side-projects`), system membership (`side-projects`), and the Kubernetes label selector used by Backstage K8s plugin to surface deployed instances across every cluster.

See `Charts/backstage-catalog/` for the static catalog this complements.

## Test plan
- [ ] Backstage on `widgetbot-internal` picks up the entity within ~30 min (GitHub Discovery default schedule)
- [ ] Component page shows the correct owner, system, and links
- [ ] Workloads in any cluster with label `backstage.io/kubernetes-id: hookla` appear in the K8s tab
