### PR TITLE
chore: add Sentry project-slug to catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,7 @@ metadata:
   description: Hookla webhook delivery service.
   annotations:
     github.com/project-slug: widgetbot-io/hookla
+    sentry.io/project-slug: hookla
     backstage.io/techdocs-ref: dir:.
     backstage.io/kubernetes-id: hookla
   links:


### PR DESCRIPTION
## Summary
Adds `sentry.io/project-slug: hookla` to `catalog-info.yaml`.

Backstage's per-entity Sentry card + Errors tab key off this annotation. With it set, opening this Component in the portal (https://backstage.widgetbot.internal/catalog/default/component/hookla) surfaces recent issues from bugs.widgetbot.co.

## Test plan
- [ ] After merge, Backstage's catalog refresher picks the new annotation up within ~30 min
- [ ] Component page shows the Errors tab populated (or a sensible empty state if there are genuinely zero issues)
